### PR TITLE
equips panic messages with info about failed object

### DIFF
--- a/chain-events/src/block_events.rs
+++ b/chain-events/src/block_events.rs
@@ -234,15 +234,14 @@ async fn process_l1_event<M, S>(
             let Ok(tx) = middleware
                 .get_transaction(
                     log.transaction_hash
-                        .expect(&format!("log always has a related transaction {:?}; qed", log)),
+                        .unwrap_or_else(|| panic!("log always has a related transaction {:?}; qed", log)),
                 )
                 .await
                 else { return };
 
-            let tx = tx.expect(&format!(
-                "mined transaction exists {:?}; qed",
-                log.transaction_hash
-            ));
+            let tx = tx.unwrap_or_else(|| {
+                panic!("mined transaction exists {:?}; qed", log.transaction_hash)
+            });
 
             let mut events = vec![];
 
@@ -250,10 +249,9 @@ async fn process_l1_event<M, S>(
                 let mut res = parse_withdrawal_events_l1(
                     &commit_blocks,
                     tx.block_number
-                        .expect(&format!(
-                            "a mined transaction {:?} has a block number; qed",
-                            tx.hash
-                        ))
+                        .unwrap_or_else(|| {
+                            panic!("a mined transaction {:?} has a block number; qed", tx.hash)
+                        })
                         .as_u64(),
                     l2_erc20_bridge_addr,
                 );

--- a/chain-events/src/l2_events.rs
+++ b/chain-events/src/l2_events.rs
@@ -121,10 +121,12 @@ impl L2EventsListener {
 
         for log in logs {
             let tx = middleware
-                .zks_get_transaction_receipt(log.transaction_hash.expect(&format!(
-                    "a log from a transaction always has a tx hash {:?}; qed",
-                    log
-                )))
+                .zks_get_transaction_receipt(log.transaction_hash.unwrap_or_else(|| {
+                    panic!(
+                        "a log from a transaction always has a tx hash {:?}; qed",
+                        log
+                    )
+                }))
                 .await
                 .map_err(|e| Error::Middleware(e.to_string()))?;
 
@@ -179,15 +181,19 @@ impl L2EventsListener {
             decimals,
             l2_block_number: bridge_init_log
                 .block_number
-                .expect(&format!(
-                    "a mined block always has a block number {:?}; qed",
-                    bridge_init_log
-                ))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "a mined block always has a block number {:?}; qed",
+                        bridge_init_log
+                    )
+                })
                 .as_u64(),
-            initialization_transaction: bridge_init_log.transaction_hash.expect(&format!(
-                "logs from mined transaction always have a known hash {:?}; qed",
-                bridge_init_log
-            )),
+            initialization_transaction: bridge_init_log.transaction_hash.unwrap_or_else(|| {
+                panic!(
+                    "logs from mined transaction always have a known hash {:?}; qed",
+                    bridge_init_log
+                )
+            }),
         };
 
         Ok(Some((l2_event, bridge_init_log.address)))
@@ -408,10 +414,12 @@ impl L2EventsListener {
                 }
                 L2Events::ContractDeployed(_) => {
                     let tx = middleware
-                        .zks_get_transaction_receipt(log.transaction_hash.expect(&format!(
-                            "a log from a transaction always has a tx hash {:?}; qed",
-                            log
-                        )))
+                        .zks_get_transaction_receipt(log.transaction_hash.unwrap_or_else(|| {
+                            panic!(
+                                "a log from a transaction always has a tx hash {:?}; qed",
+                                log
+                            )
+                        }))
                         .await
                         .map_err(|e| Error::Middleware(e.to_string()))?;
 


### PR DESCRIPTION
mainnet panicked with

```
[Sentry]: panic: a mined transaction has a block number; qed
```

This expands this message to investigate such cases.