### PR TITLE
fix: ignore non deployer contract deployed events 

### DIFF
--- a/chain-events/src/l2_events.rs
+++ b/chain-events/src/l2_events.rs
@@ -375,6 +375,7 @@ impl L2EventsListener {
                 Ok(log) => log,
             };
             let raw_log: RawLog = log.clone().into();
+            metrics::increment_counter!("watcher.chain_events.l2_logs_received");
             successful_logs += 1;
 
             if should_attempt_pagination_increase(pagination_step, successful_logs) {
@@ -386,7 +387,7 @@ impl L2EventsListener {
             }
 
             if let Ok(l2_event) = L2Events::decode_log(&raw_log) {
-                metrics::increment_counter!("watcher.chain_events.l2_logs_received");
+                metrics::increment_counter!("watcher.chain_events.l2_logs_decoded");
                 if let L2Events::ContractDeployed(_) = l2_event {
                     if log.topics.get(1) != Some(&DEPLOYER_ADDRESS.into()) {
                         continue;


### PR DESCRIPTION
- fix: ignore all non-deployer deployed contract events
- move a metric
