### PR TITLE
ci: create migration_deployment.yml

### DIFF
--- a/.github/workflows/migration_deployment.yml
+++ b/.github/workflows/migration_deployment.yml
@@ -23,9 +23,6 @@ jobs:
       options: --user root
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
-        with:
-          submodules: "recursive"
-          token: ${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}
 
       - name: setup-env
         shell: bash


### PR DESCRIPTION
Mostly a copypaste from `zksync-2-dev` with deleted auth for closed repos since at this moment no dependencies on private repos are used.