### PR TITLE
fix: l2 to l1 message should be searched by hash only

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -390,10 +390,7 @@ impl<P: JsonRpcClient> ZksyncMiddleware for Provider<P> {
         let l2_to_l1_log_index = receipt
             .l2_to_l1_logs
             .iter()
-            .enumerate()
-            .filter(|(_, log)| log.value == l2_to_l1_message_hash)
-            .nth(index)
-            .map(|(i, _)| i)
+            .position(|l| l.value == l2_to_l1_message_hash)
             .ok_or(Error::L2ToL1WithValueNotFound(
                 withdrawal_hash,
                 l2_to_l1_message_hash,


### PR DESCRIPTION
Initially code in the pr #153 was right, but then after review it was fixed to take the n-th index of the iterator in question. However that is wrong:
1. iterator searches for l2tol1messages by a hash
2. the hash is unique and as such there is always only one such l2tol1message with this hash
3. it _is_ the neededed l2tol1message