### PR TITLE
chore: fix typos

### DIFF
--- a/chain-events/src/block_events.rs
+++ b/chain-events/src/block_events.rs
@@ -26,7 +26,7 @@ enum L1Events {
 
 // A convenience multiplexer for `Block`-related events.
 //
-// The only purose of this structure is multpliexing together
+// The only purpose of this structure is multiplexing together
 // the `Block` events from the middleware as currently `ethers` events
 // api relies on lifetimes and borrowing is hard to use otherwise
 // in the async context.

--- a/finalizer/src/lib.rs
+++ b/finalizer/src/lib.rs
@@ -311,7 +311,7 @@ where
                     tokio::time::sleep(OUT_OF_FUNDS_BACKOFF).await;
                 }
                 // no need to bump the counter here, waiting for tx
-                // has failed becuase of networking or smth, but at
+                // has failed because of networking or smth, but at
                 // this point tx has already been accepted into tx pool
             }
         }
@@ -472,7 +472,7 @@ where
 
         // if the withdrawal has already been finalized set its
         // finalization transaction to zero which is signals exactly this
-        // it is known that withdrawal has been fianlized but not known
+        // it is known that withdrawal has been finalized but not known
         // in which exact transaction.
         //
         // this may happen in two cases:
@@ -554,7 +554,7 @@ where
 {
     let mut ok_results = Vec::with_capacity(hash_and_indices.len());
 
-    // Run all parametere fetching in parallel.
+    // Run all parameter fetching in parallel.
     // Filter out errors and log them and increment a metric counter.
     // Return successful fetches.
     for (i, result) in futures::future::join_all(hash_and_indices.iter().map(|(h, i, id)| {
@@ -591,7 +591,7 @@ where
     ok_results
 }
 
-// Continiously query the new withdrawals that have been seen by watcher
+// Continuously query the new withdrawals that have been seen by watcher
 // request finalizing params for them and store this information into
 // finalizer db table.
 async fn params_fetcher_loop<M1, M2>(

--- a/watcher/src/lib.rs
+++ b/watcher/src/lib.rs
@@ -71,11 +71,11 @@ where
             withdrawals_meterer,
         } = self;
 
-        // While reading the stream of withdrawal events asyncronously
-        // we may never be sure that we are currenly looking at the last
+        // While reading the stream of withdrawal events asynchronously
+        // we may never be sure that we are currently looking at the last
         // event from the given block.
         //
-        // The following code asyncronously reads and accumulates events
+        // The following code asynchronously reads and accumulates events
         // that happened within the single block (the exact number is tracked in
         // `curr_block_number`) until it sees an event with a higher block number.
         // Then the following vector is drained and all events within it are written


### PR DESCRIPTION
1. Fix `chain-events/src/block_events.rs`  typo
2. Fix `finalizer/src/lib.rs`  typo
3. Fix `watcher/src/lib.rs`  typo