### PR TITLE
fix: do not track l2_to_l1_logs block height on restart

### DIFF
--- a/bin/withdrawal-finalizer/src/main.rs
+++ b/bin/withdrawal-finalizer/src/main.rs
@@ -56,25 +56,13 @@ where
     M2: Middleware,
     <M2 as Middleware>::Provider: JsonRpcClient,
 {
-    match (
-        storage::last_l2_to_l1_events_block_seen(conn).await?,
-        storage::last_l1_block_seen(conn).await?,
-    ) {
-        (Some(b1), Some(b2)) => Ok(std::cmp::min(b1, b2)),
-        (b1, b2) => {
-            if b1.is_none() {
-                tracing::info!(concat!(
-                    "information about l2 to l1 events is missing, ",
-                    "starting from L1 block corresponding to L2 block 1"
-                ));
-            }
-
-            if b2.is_none() {
-                tracing::info!(concat!(
-                    "information about last block seen is missing, ",
-                    "starting from L1 block corresponding to L2 block 1"
-                ));
-            }
+    match storage::last_l1_block_seen(conn).await? {
+        Some(b2) => Ok(b2),
+        None => {
+            tracing::info!(concat!(
+                "information about last block seen is missing, ",
+                "starting from L1 block corresponding to L2 block 1"
+            ));
 
             let block_details = client_l2
                 .provider()


### PR DESCRIPTION
# What ❔

We are currently no longer track L2ToL1Logs from L1 (removed in #398 ), so no need to try to start from the last seen block for those events

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt`.
