### PR TITLE
docs: correct typos, capitalization, and update link in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Withdrawal Finalizer in Rust.
 
 ## Purpose
 
-Withdrawal Finalizer is a component of `zksync-era` responsible for monitoring and finalizing [L2->L1 withdrawals](https://github.com/matter-labs/zksync-era/blob/main/docs/advanced/03_withdrawals.md). It does so by continuously monitoring events happening on both L2 and L1, keeping some state in persistent storage (which is PostgreSQL) and sending withdrawal finalization transactions whenever necessary.
+Withdrawal Finalizer is a component of `zksync-era` responsible for monitoring and finalizing [L2->L1 withdrawals](https://github.com/matter-labs/zksync-era/blob/main/docs/src/guides/advanced/03_withdrawals.md). It does so by continuously monitoring events happening on both L2 and L1, keeping some state in persistent storage (which is PostgreSQL) and sending withdrawal finalization transactions whenever necessary.
 
 ## Building
 
@@ -46,7 +46,7 @@ Deployment is done by deploying a dockerized image of the service.
 | `CONTRACTS_WITHDRAWAL_FINALIZER_CONTRACT` | Address of the Withdrawal Finalizer contract ** |
 | `API_WEB3_JSON_RPC_WS_URL` | Address of the zkSync Era WebSocket RPC endpoint |
 | `API_WEB3_JSON_RPC_HTTP_URL` | Address of the zkSync Era HTTP RPC endpoint |
-| `DATABSE_URL` | The url of PostgreSQL database the service stores its state into |
+| `DATABASE_URL` | The url of PostgreSQL database the service stores its state into |
 | `GAS_LIMIT` | The gas limit of a single withdrawal finalization within the batch of withdrawals finalized in a call to `finalizeWithdrawals` in WithdrawalFinalizerContract |
 | `BATCH_FINALIZATION_GAS_LIMIT` | The gas limit of the finalization of the whole batch in a call to `finalizeWithdrawals` in Withdrawal Finalizer Contract |
 | `WITHDRAWAL_FINALIZER_ACCOUNT_PRIVATE_KEY` | The private key of the account that is going to be submit finalization transactions |
@@ -54,7 +54,7 @@ Deployment is done by deploying a dockerized image of the service.
 | `FINALIZE_ETH_TOKEN` | (Optional) Configure, whether the Ethereum withdrawal events should be monitored. Useful to turn off for custom bridges that are only interested in a particular ERC20 token and have nothing to do with main Ethereum withdrawals |
 | `CUSTOM_TOKEN_DEPLOYER_ADDRESSES` | (Optional) Normally ERC20 tokens are deployed by the bridge contract. However, in custom cases it may be necessary to override that behavior with a custom set of addresses that have deployed tokens |
 | `CUSTOM_TOKEN_ADDRESSES` | (Optional) Adds a predefined list of tokens to finalize. May be useful in case of custom bridge setups when the regular technique of finding token deployments does not work. |
-| `ENABLE_WITHDRAWAL_METERING` | (Optional, default: `"true"`) By default Finalizer collects metrics about withdrawn token volumens. Users may optionally switch off this metering. |
+| `ENABLE_WITHDRAWAL_METERING` | (Optional, default: `"true"`) By default Finalizer collects metrics about withdrawn token volumes. Users may optionally switch off this metering. |
 | `ETH_FINALIZATION_THRESHOLD`| (Optional, default: "0") Finalizer will only finalize ETH withdrawals that are greater or equal to this value |
 | `ONLY_FINALIZE_THESE_TOKENS` | (Optional, default: `None`) If specified, creates a whitelist of erc20 tokens that will be finalized.
 
@@ -64,7 +64,7 @@ The configuration structure describing the service config can be found in [`conf
 
 ## Deploying the finalizer smart contract
 
-The finalizer smart contract needs to reference the addresses of the diamond proxy contract and l1 erc20 proxy contract.
+The finalizer smart contract needs to reference the addresses of the diamond proxy contract and L1 ERC20 proxy contract.
 You also need to know the key of the account you want to use to deploy the finalizer contract.
 
 When you know those to deploy the contract you need to run (assume you are running `anvil` in a separate terminal):
@@ -74,7 +74,7 @@ $ yarn
 $ env CONTRACTS_DIAMOND_PROXY_ADDR="0x9A6DE0f62Aa270A8bCB1e2610078650D539B1Ef9" CONTRACTS_L1_ERC20_BRIDGE_PROXY_ADDR="0x2Ae09702F77a4940621572fBcDAe2382D44a2cbA" MNEMONIC="test test test test test test test test test test test junk" ETH_CLIENT_WEB3_URL="http://localhost:8545" npx hardhat run ./scripts/deploy.ts
 ```
 
-If all goes well the the result would be
+If all goes well the result would be
 
 ```
 ...


### PR DESCRIPTION
### 1. **Fixed Typo: "DATABSE_URL" → "DATABASE_URL"**  
   - The term "DATABSE_URL" was misspelled and has been corrected to "DATABASE_URL."  

### 2. **Fixed Typo: "volumens" → "volumes"**  
   - The word "volumens" was incorrect and has been updated to "volumes."  

### 3. **Updated "l1 erc20" → "L1 ERC20"**  
   - Corrected the capitalization of "l1 erc20" to "L1 ERC20" to follow proper naming conventions.  

### 4. **Removed Redundant Phrase: "the the" → "the"**  
   - The duplicate "the the" was removed and replaced with a single "the."  

### 5. **Updated Link**  
   - Updated the link to the correct version, as shown in the "before" and "after" images.
   **before:**
![image](https://github.com/user-attachments/assets/530e4fbc-4b38-43de-beec-25895db900db)
   **after:**
![image](https://github.com/user-attachments/assets/d14fc677-c45c-4297-9adf-1f95695a0d08)
