### PR TITLE
fix: do not panic if proof is null

### DIFF
--- a/bin/withdrawal-finalizer/src/metrics.rs
+++ b/bin/withdrawal-finalizer/src/metrics.rs
@@ -1,5 +1,7 @@
 //! Metrics for main binary
 
+#![allow(unexpected_cfgs)]
+
 use std::time::Duration;
 
 use ethers::types::U256;
@@ -25,7 +27,6 @@ pub(super) struct FinalizerMainMetrics {
     pub unexecuted_eth_withdrawals_below_current_threshold: Gauge,
 }
 
-#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static MAIN_FINALIZER_METRICS: vise::Global<FinalizerMainMetrics> = vise::Global::new();
 

--- a/bin/withdrawal-finalizer/src/metrics.rs
+++ b/bin/withdrawal-finalizer/src/metrics.rs
@@ -25,6 +25,7 @@ pub(super) struct FinalizerMainMetrics {
     pub unexecuted_eth_withdrawals_below_current_threshold: Gauge,
 }
 
+#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static MAIN_FINALIZER_METRICS: vise::Global<FinalizerMainMetrics> = vise::Global::new();
 

--- a/chain-events/src/metrics.rs
+++ b/chain-events/src/metrics.rs
@@ -1,5 +1,7 @@
 //! Metrics for chain events
 
+#![allow(unexpected_cfgs)]
+
 use vise::{Counter, Gauge, Metrics};
 
 /// Chain events metrics.
@@ -43,6 +45,5 @@ pub(super) struct ChainEventsMetrics {
     pub block_execution_events: Counter,
 }
 
-#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static CHAIN_EVENTS_METRICS: vise::Global<ChainEventsMetrics> = vise::Global::new();

--- a/chain-events/src/metrics.rs
+++ b/chain-events/src/metrics.rs
@@ -43,5 +43,6 @@ pub(super) struct ChainEventsMetrics {
     pub block_execution_events: Counter,
 }
 
+#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static CHAIN_EVENTS_METRICS: vise::Global<ChainEventsMetrics> = vise::Global::new();

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -415,10 +415,13 @@ impl<P: JsonRpcClient> ZksyncMiddleware for Provider<P> {
 
         let sender = log.topics[1].into();
 
-        let proof = self
+        // Proof can be not ready yet.
+        let Some(proof) = self
             .get_log_proof(withdrawal_hash, Some(l2_to_l1_log_index as u64))
             .await?
-            .expect("Log proof should be present. qed");
+        else {
+            return Ok(None);
+        };
 
         let message: Bytes = match ethers::abi::decode(&[ParamType::Bytes], &log.data)
             .expect("log data is valid rlp data; qed")

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -1,5 +1,7 @@
 //! Metrics for client
 
+#![allow(unexpected_cfgs)]
+
 use std::time::Duration;
 
 use vise::{Buckets, Histogram, LabeledFamily, Metrics};
@@ -12,6 +14,5 @@ pub(super) struct ClientMetrics {
     pub call: LabeledFamily<&'static str, Histogram<Duration>>,
 }
 
-#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static CLIENT_METRICS: vise::Global<ClientMetrics> = vise::Global::new();

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -12,5 +12,6 @@ pub(super) struct ClientMetrics {
     pub call: LabeledFamily<&'static str, Histogram<Duration>>,
 }
 
+#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static CLIENT_METRICS: vise::Global<ClientMetrics> = vise::Global::new();

--- a/deny.toml
+++ b/deny.toml
@@ -12,7 +12,9 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
 ignore = [
-    "RUSTSEC-2023-0052"
+    "RUSTSEC-2023-0052",
+    "RUSTSEC-2024-0384",
+    "RUSTSEC-2024-0421"
 ]
 
 [licenses]

--- a/finalizer/src/lib.rs
+++ b/finalizer/src/lib.rs
@@ -44,6 +44,9 @@ const OUT_OF_FUNDS_BACKOFF: Duration = Duration::from_secs(10);
 /// Backoff period if one of the loop iterations has failed.
 const LOOP_ITERATION_ERROR_BACKOFF: Duration = Duration::from_secs(5);
 
+/// Interval between successful loop iterations.
+const LOOP_ITERATION_OK_INTERVAL: Duration = Duration::from_secs(1);
+
 /// A newtype that represents a set of addresses in JSON format.
 #[derive(Debug, Eq, PartialEq)]
 pub struct AddrList(pub Vec<Address>);
@@ -491,11 +494,12 @@ fn is_gas_required_exceeds_allowance<M: Middleware>(e: &<M as Middleware>::Error
 }
 
 // Request finalization parameters for a set of withdrawals in parallel.
+// Returns `None` if params for some withdrawal are not ready yet.
 async fn request_finalize_params<M2>(
     pgpool: &PgPool,
     middleware: M2,
     hash_and_indices: &[(H256, u16, u64)],
-) -> Vec<WithdrawalParams>
+) -> Option<Vec<WithdrawalParams>>
 where
     M2: ZksyncMiddleware,
 {
@@ -504,20 +508,28 @@ where
     // Run all parametere fetching in parallel.
     // Filter out errors and log them and increment a metric counter.
     // Return successful fetches.
-    for (i, result) in futures::future::join_all(hash_and_indices.iter().map(|(h, i, id)| {
+    let params_opt = futures::future::join_all(hash_and_indices.iter().map(|(h, i, id)| {
         middleware
             .finalize_withdrawal_params(*h, *i as usize)
-            .map_ok(|r| {
-                let mut r = r.expect("always able to ask withdrawal params; qed");
-                r.id = *id;
+            .map_ok(|mut r| {
+                r.as_mut().map(|r| r.id = *id);
                 r
             })
             .map_err(crate::Error::from)
     }))
-    .await
-    .into_iter()
-    .enumerate()
-    {
+    .await;
+
+    // If any element is `None` then return `None`.
+    let mut params = Vec::with_capacity(params_opt.len());
+    for result in params_opt {
+        match result {
+            Ok(Some(param)) => params.push(Ok(param)),
+            Ok(None) => return None,
+            Err(err) => params.push(Err(err)),
+        }
+    }
+
+    for (i, result) in params.into_iter().enumerate() {
         match result {
             Ok(r) => ok_results.push(r),
             Err(e) => {
@@ -535,7 +547,7 @@ where
         }
     }
 
-    ok_results
+    Some(ok_results)
 }
 
 // Continiously query the new withdrawals that have been seen by watcher
@@ -556,6 +568,8 @@ async fn params_fetcher_loop<M1, M2>(
         {
             tracing::error!("params fetcher iteration ended with {e}");
             tokio::time::sleep(LOOP_ITERATION_ERROR_BACKOFF).await;
+        } else {
+            tokio::time::sleep(LOOP_ITERATION_OK_INTERVAL).await;
         }
     }
 }
@@ -584,7 +598,12 @@ where
         .map(|p| (p.key.tx_hash, p.key.event_index_in_tx as u16, p.id))
         .collect();
 
-    let params = request_finalize_params(pool, &middleware, &hash_and_index_and_id).await;
+    let Some(params) = request_finalize_params(pool, &middleware, &hash_and_index_and_id).await
+    else {
+        // Early-return if params are not ready.
+        tracing::info!("newly committed withdrawals {newly_executed_withdrawals:?}");
+        return Ok(());
+    };
 
     let already_finalized: Vec<_> = get_finalized_withdrawals(&params, zksync_contract, l1_bridge)
         .await?

--- a/finalizer/src/lib.rs
+++ b/finalizer/src/lib.rs
@@ -603,7 +603,7 @@ where
     let Some(params) = request_finalize_params(pool, &middleware, &hash_and_index_and_id).await
     else {
         // Early-return if params are not ready.
-        tracing::info!("newly committed withdrawals {newly_executed_withdrawals:?}");
+        tracing::info!("Params are not ready");
         return Ok(());
     };
 

--- a/finalizer/src/lib.rs
+++ b/finalizer/src/lib.rs
@@ -512,7 +512,9 @@ where
         middleware
             .finalize_withdrawal_params(*h, *i as usize)
             .map_ok(|mut r| {
-                r.as_mut().map(|r| r.id = *id);
+                if let Some(r) = r.as_mut() {
+                    r.id = *id;
+                }
                 r
             })
             .map_err(crate::Error::from)

--- a/finalizer/src/metrics.rs
+++ b/finalizer/src/metrics.rs
@@ -1,5 +1,7 @@
 //! Metrics for finalizer
 
+#![allow(unexpected_cfgs)]
+
 use vise::{Counter, Gauge, Metrics};
 
 /// Finalizer metrics
@@ -22,6 +24,5 @@ pub(super) struct FinalizerMetrics {
     pub reverted_withdrawal_transactions: Counter,
 }
 
-#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static FINALIZER_METRICS: vise::Global<FinalizerMetrics> = vise::Global::new();

--- a/finalizer/src/metrics.rs
+++ b/finalizer/src/metrics.rs
@@ -22,5 +22,6 @@ pub(super) struct FinalizerMetrics {
     pub reverted_withdrawal_transactions: Counter,
 }
 
+#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static FINALIZER_METRICS: vise::Global<FinalizerMetrics> = vise::Global::new();

--- a/storage/src/metrics.rs
+++ b/storage/src/metrics.rs
@@ -1,5 +1,7 @@
 //! Metrics for storage
 
+#![allow(unexpected_cfgs)]
+
 use std::time::Duration;
 
 use vise::{Buckets, Histogram, LabeledFamily, Metrics};
@@ -12,6 +14,5 @@ pub(super) struct StorageMetrics {
     pub call: LabeledFamily<&'static str, Histogram<Duration>>,
 }
 
-#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static STORAGE_METRICS: vise::Global<StorageMetrics> = vise::Global::new();

--- a/storage/src/metrics.rs
+++ b/storage/src/metrics.rs
@@ -12,5 +12,6 @@ pub(super) struct StorageMetrics {
     pub call: LabeledFamily<&'static str, Histogram<Duration>>,
 }
 
+#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static STORAGE_METRICS: vise::Global<StorageMetrics> = vise::Global::new();

--- a/tx-sender/src/metrics.rs
+++ b/tx-sender/src/metrics.rs
@@ -10,5 +10,6 @@ pub(super) struct TxSenderMetrics {
     pub timedout_transactions: Counter,
 }
 
+#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static TX_SENDER_METRICS: vise::Global<TxSenderMetrics> = vise::Global::new();

--- a/tx-sender/src/metrics.rs
+++ b/tx-sender/src/metrics.rs
@@ -1,5 +1,7 @@
 //! Metrics for tx sender
 
+#![allow(unexpected_cfgs)]
+
 use vise::{Counter, Metrics};
 
 /// TX Sender metrics
@@ -10,6 +12,5 @@ pub(super) struct TxSenderMetrics {
     pub timedout_transactions: Counter,
 }
 
-#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static TX_SENDER_METRICS: vise::Global<TxSenderMetrics> = vise::Global::new();

--- a/watcher/src/metrics.rs
+++ b/watcher/src/metrics.rs
@@ -19,5 +19,6 @@ pub(super) struct WatcherMetrics {
     pub l2_last_seen_block: Gauge,
 }
 
+#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static WATCHER_METRICS: vise::Global<WatcherMetrics> = vise::Global::new();

--- a/watcher/src/metrics.rs
+++ b/watcher/src/metrics.rs
@@ -1,5 +1,7 @@
 //! Metrics for withdrawal watcher
 
+#![allow(unexpected_cfgs)]
+
 use vise::{Gauge, Metrics};
 
 /// Watcher metrics
@@ -19,6 +21,5 @@ pub(super) struct WatcherMetrics {
     pub l2_last_seen_block: Gauge,
 }
 
-#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static WATCHER_METRICS: vise::Global<WatcherMetrics> = vise::Global::new();

--- a/withdrawals-meterer/src/metrics.rs
+++ b/withdrawals-meterer/src/metrics.rs
@@ -29,5 +29,6 @@ pub(super) struct WithdrawalsMetererMetrics {
     pub withdrawals: LabeledFamily<Labels, Gauge<f64>, 2>,
 }
 
+#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static WM_METRICS: vise::Global<WithdrawalsMetererMetrics> = vise::Global::new();

--- a/withdrawals-meterer/src/metrics.rs
+++ b/withdrawals-meterer/src/metrics.rs
@@ -1,5 +1,7 @@
 //! Metrics for withdrawal meterer
 
+#![allow(unexpected_cfgs)]
+
 use vise::{EncodeLabelSet, EncodeLabelValue, Family, Gauge, LabeledFamily, Metrics};
 
 /// Kinds of withdrawal volumes currently being metered by application
@@ -29,6 +31,5 @@ pub(super) struct WithdrawalsMetererMetrics {
     pub withdrawals: LabeledFamily<Labels, Gauge<f64>, 2>,
 }
 
-#[allow(unexpected_cfgs)]
 #[vise::register]
 pub(super) static WM_METRICS: vise::Global<WithdrawalsMetererMetrics> = vise::Global::new();


### PR DESCRIPTION
# What ❔

do not panic if proof is null, wait until it's ready instead

## Why ❔

proofs are calculated asynchronously with v26 upgrade, so it can be that proof is not ready for some short period after withdrawal's block is finalized

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt`.
